### PR TITLE
Fix apiVersion for audit policy

### DIFF
--- a/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2
+++ b/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
 {% if audit_policy_custom_rules is defined and audit_policy_custom_rules != "" %}


### PR DESCRIPTION
Should be apiVersion: audit.k8s.io/v1 not [audit.k8s.io/v1beta1](https://github.com/kubernetes-sigs/kubespray/blob/56f389a9f386767fa347732890889033d4e2c91d/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2#L1)

Has been v1 since [k8s v1.14](https://v1-14.docs.kubernetes.io/docs/tasks/debug-application-cluster/audit/) or earlier.

Fixes issue #6525